### PR TITLE
Propriedade click-overlay-to-close para ser usada sem service

### DIFF
--- a/src/app/demo/demo-dialog/demo-dialog.component.html
+++ b/src/app/demo/demo-dialog/demo-dialog.component.html
@@ -1,8 +1,11 @@
 <div class="ui-button-container">
     <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple>Open Dialog</button>
     <button class="ui-button raised primary" uiRipple (click)="openWithService(testDialog)">Open Dialog with service</button>
-    <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple transparent-overlay="true" click-overlay-to-close="false">
+    <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple transparent-overlay="true">
         Open Dialog with Transparent Overlay
+    </button>
+    <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple [click-overlay-to-close]="false">
+        Dialog don't close when click in the overlay
     </button>
 </div>
 

--- a/src/app/smn-ui/dialog/dialog-trigger.directive.ts
+++ b/src/app/smn-ui/dialog/dialog-trigger.directive.ts
@@ -1,5 +1,5 @@
-import {AfterViewInit, Directive, ElementRef, Input, ViewContainerRef} from '@angular/core';
-import {UiElement} from '../utils/providers/element.provider';
+import { AfterViewInit, Directive, ElementRef, Input, ViewContainerRef } from '@angular/core';
+import { UiElement } from '../utils/providers/element.provider';
 
 @Directive({
     selector: '[uiDialogTrigger]'
@@ -12,6 +12,7 @@ export class UiDialogTriggerDirective implements AfterViewInit {
     @Input('theme-class') themeClass: string;
     @Input('transparent-overlay') transparentOverlay: boolean;
     @Input('uiDialogTrigger') dialog;
+    @Input('click-overlay-to-close') clickOverlayToClose;
 
     constructor(public viewContainerRef: ViewContainerRef, public elementRef: ElementRef) {
     }
@@ -24,6 +25,8 @@ export class UiDialogTriggerDirective implements AfterViewInit {
         UiElement.on(this.elementRef.nativeElement, this.triggerEvents || 'click', () => {
             this.render();
         });
+
+        this.clickOverlayToClose = this.clickOverlayToClose !== undefined ? this.clickOverlayToClose : true;
     }
 
     render() {
@@ -63,9 +66,12 @@ export class UiDialogTriggerDirective implements AfterViewInit {
                     fab.classList.add('hide');
                 });
             }
-            element.querySelectorAll('.overlay')[0].addEventListener('click', () => {
-                this.close();
-            });
+
+            if (this.clickOverlayToClose) {
+                element.querySelectorAll('.overlay')[0].addEventListener('click', () => {
+                    this.close();
+                });
+            }
 
             element.style.transform = '';
 


### PR DESCRIPTION
Adicionada propriedade para cancelar o close do dialog no click na overlay sem o uso de service.
Ex: [click-overlay-to-close]="false" -> no elemento que efetua o trigger do dialog.