### PR TITLE
Removendo eventos de touch quando o nav-drawer é destruido

### DIFF
--- a/projects/smn-ui/src/lib/nav-drawer/nav-drawer.component.ts
+++ b/projects/smn-ui/src/lib/nav-drawer/nav-drawer.component.ts
@@ -24,6 +24,9 @@ export class UiNavDrawerComponent implements AfterViewInit, OnChanges, OnDestroy
     @Output() openChange: EventEmitter<boolean> = new EventEmitter<boolean>();
     public openNav: Function;
     public closeNav: Function;
+    onTouchStart: Function;
+    onTouchMove: Function;
+    onTouchEnd: Function;
 
     constructor(private element: ElementRef) {
         this.openNav = () => {
@@ -89,13 +92,13 @@ export class UiNavDrawerComponent implements AfterViewInit, OnChanges, OnDestroy
         let mouseX;
         let mouseXMovement;
 
-        UiElement.on(window, 'touchstart', (e) => {
+        this.onTouchStart = (e) => {
             mouseX = e.touches[0].pageX;
             navDrawerTouch = (mouseX > 0 && mouseX < 40) ? 'open' : navDrawerTouch;
             navDrawerTouch = (mouseX > 320 && mouseX < 360) ? 'close' : navDrawerTouch;
-        });
+        };
 
-        UiElement.on(window, 'touchmove', (e) => {
+        this.onTouchMove = (e) => {
             if (navDrawerTouch) {
                 mouseXMovement = e.touches[0].pageX - mouseX;
                 if (navDrawerTouch === 'open' && !this.open) {
@@ -107,9 +110,9 @@ export class UiNavDrawerComponent implements AfterViewInit, OnChanges, OnDestroy
                     UiElement.css(navDrawer, 'transform', 'translateX(' + (mouseXMovement) + 'px)');
                 }
             }
-        });
+        };
 
-        UiElement.on(window, 'touchend', () => {
+        this.onTouchEnd = (e) => {
             if (navDrawerTouch) {
                 if (navDrawerTouch === 'open' && mouseXMovement > 20) {
                     UiElement.css(navDrawer, 'transform', '');
@@ -127,7 +130,11 @@ export class UiNavDrawerComponent implements AfterViewInit, OnChanges, OnDestroy
             }
 
             navDrawerTouch = undefined;
-        });
+        };
+
+        UiElement.on(window, 'touchstart', this.onTouchStart);
+        UiElement.on(window, 'touchmove', this.onTouchMove);
+        UiElement.on(window, 'touchend', this.onTouchEnd);
     }
 
     ngOnChanges(changes) {
@@ -168,6 +175,9 @@ export class UiNavDrawerComponent implements AfterViewInit, OnChanges, OnDestroy
     }
 
     ngOnDestroy() {
+        UiElement.off(window, 'touchstart', this.onTouchStart);
+        UiElement.off(window, 'touchmove', this.onTouchMove);
+        UiElement.off(window, 'touchend', this.onTouchEnd);
         document.body.classList.add('notransition');
         document.body.classList.remove('ui-nav-drawer-persistent');
         setTimeout(() => {

--- a/src/app/demo/demo-dialog/demo-dialog.component.html
+++ b/src/app/demo/demo-dialog/demo-dialog.component.html
@@ -4,7 +4,7 @@
     <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple transparent-overlay="true">
         Open Dialog with Transparent Overlay
     </button>
-    <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" uiRipple [click-overlay-to-close]="false">
+    <button class="ui-button raised primary" [uiDialogTrigger]="testDialog" [click-overlay-to-close]="true" uiRipple>
         Dialog don't close when click in the overlay
     </button>
 </div>

--- a/src/app/demo/demo-menu/demo-menu.component.html
+++ b/src/app/demo/demo-menu/demo-menu.component.html
@@ -2,7 +2,7 @@
     <ui-card>
         <ui-card-content>
             <div>
-                <button class="ui-button icon flat" uiRipple [uiMenuTrigger]="testeMenu" [clickOverlayToClose]="true">
+                <button class="ui-button icon flat" uiRipple [uiMenuTrigger]="testeMenu" [click-overlay-to-close]="true">
                     <i class="material-icons">more_vert</i>
                 </button>
                 <span>Menu left aligned</span>


### PR DESCRIPTION
Quando o component nav-drawer é destruído os eventos de touch (start, move e end) são retirados do window.